### PR TITLE
[WL7-134]반경 내 제휴처 리스트 불러오기 ( Add API to retrieve partner places within event radius and refactor DTOs )

### DIFF
--- a/src/main/java/com/unear/admin/event/controller/EventController.java
+++ b/src/main/java/com/unear/admin/event/controller/EventController.java
@@ -3,7 +3,7 @@ package com.unear.admin.event.controller;
 import com.unear.admin.coupon.dto.CouponTemplateRequestDto;
 import com.unear.admin.event.dto.EventRequestDto;
 import com.unear.admin.event.service.EventService;
-import com.unear.admin.places.dto.PlaceRequestDto;
+import com.unear.admin.places.dto.requestdto.PlaceRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/unear/admin/event/service/EventService.java
+++ b/src/main/java/com/unear/admin/event/service/EventService.java
@@ -2,7 +2,7 @@ package com.unear.admin.event.service;
 
 import com.unear.admin.coupon.dto.CouponTemplateRequestDto;
 import com.unear.admin.event.dto.EventRequestDto;
-import com.unear.admin.places.dto.PlaceRequestDto;
+import com.unear.admin.places.dto.requestdto.PlaceRequestDto;
 
 public interface EventService {
 

--- a/src/main/java/com/unear/admin/event/service/impl/UnearEventServiceImpl.java
+++ b/src/main/java/com/unear/admin/event/service/impl/UnearEventServiceImpl.java
@@ -7,7 +7,7 @@ import com.unear.admin.event.dto.EventRequestDto;
 import com.unear.admin.event.entity.Event;
 import com.unear.admin.event.repository.EventRepository;
 import com.unear.admin.event.service.EventService;
-import com.unear.admin.places.dto.PlaceRequestDto;
+import com.unear.admin.places.dto.requestdto.PlaceRequestDto;
 import com.unear.admin.places.entity.Place;
 import com.unear.admin.places.repository.PlaceRepository;
 import jakarta.transaction.Transactional;

--- a/src/main/java/com/unear/admin/places/controller/PlaceController.java
+++ b/src/main/java/com/unear/admin/places/controller/PlaceController.java
@@ -1,12 +1,15 @@
 package com.unear.admin.places.controller;
 
 import com.unear.admin.common.response.ApiResponse;
-import com.unear.admin.places.dto.PlaceRequestDto;
+import com.unear.admin.places.dto.requestdto.PlaceRequestDto;
+import com.unear.admin.places.dto.responsedto.PlaceResponseDto;
 import com.unear.admin.places.service.PlaceService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/admin/places")
@@ -23,4 +26,12 @@ public class PlaceController {
         placeService.savePlace(eventId, request);
         return ResponseEntity.ok(ApiResponse.success("팝업스토어 등록 성공"));
     }
+
+    @GetMapping("/{eventId}/partners")
+    public ResponseEntity<List<PlaceResponseDto>> getPartnersWithinEventRadius(
+            @PathVariable Long eventId
+    ) {
+        return ResponseEntity.ok(placeService.getPartnersWithinEvent(eventId));
+    }
+
 }

--- a/src/main/java/com/unear/admin/places/controller/PlaceController.java
+++ b/src/main/java/com/unear/admin/places/controller/PlaceController.java
@@ -28,10 +28,10 @@ public class PlaceController {
     }
 
     @GetMapping("/{eventId}/partners")
-    public ResponseEntity<List<PlaceResponseDto>> getPartnersWithinEventRadius(
-            @PathVariable Long eventId
+    public ResponseEntity<ApiResponse<List<PlaceResponseDto>>> getPartnersWithinEventRadius(
+            @PathVariable @Min(1) Long eventId
     ) {
-        return ResponseEntity.ok(placeService.getPartnersWithinEvent(eventId));
+        List<PlaceResponseDto> partners = placeService.getPartnersWithinEvent(eventId);
+        return ResponseEntity.ok(ApiResponse.success(partners));
     }
-
 }

--- a/src/main/java/com/unear/admin/places/dto/requestdto/PlaceRequestDto.java
+++ b/src/main/java/com/unear/admin/places/dto/requestdto/PlaceRequestDto.java
@@ -1,4 +1,4 @@
-package com.unear.admin.places.dto;
+package com.unear.admin.places.dto.requestdto;
 
 import com.unear.admin.common.enums.PlaceCategory;
 import com.unear.admin.common.enums.PlaceType;

--- a/src/main/java/com/unear/admin/places/dto/responsedto/PlaceResponseDto.java
+++ b/src/main/java/com/unear/admin/places/dto/responsedto/PlaceResponseDto.java
@@ -2,13 +2,15 @@ package com.unear.admin.places.dto.responsedto;
 
 import com.unear.admin.places.entity.Place;
 
+import java.math.BigDecimal;
+
 public record PlaceResponseDto(
         Long id,
         String name,
         String address,
         String tel,
-        double latitude,
-        double longitude
+        BigDecimal latitude,
+        BigDecimal longitude
 ) {
     public static PlaceResponseDto from(Place place) {
         return new PlaceResponseDto(
@@ -16,8 +18,8 @@ public record PlaceResponseDto(
                 place.getPlaceName(),
                 place.getAddress(),
                 place.getTel(),
-                place.getLatitude().doubleValue(),
-                place.getLongitude().doubleValue()
+                place.getLatitude() != null ? place.getLatitude() : BigDecimal.ZERO,
+                place.getLongitude() != null ? place.getLongitude() : BigDecimal.ZERO
         );
     }
 }

--- a/src/main/java/com/unear/admin/places/dto/responsedto/PlaceResponseDto.java
+++ b/src/main/java/com/unear/admin/places/dto/responsedto/PlaceResponseDto.java
@@ -1,0 +1,23 @@
+package com.unear.admin.places.dto.responsedto;
+
+import com.unear.admin.places.entity.Place;
+
+public record PlaceResponseDto(
+        Long id,
+        String name,
+        String address,
+        String tel,
+        double latitude,
+        double longitude
+) {
+    public static PlaceResponseDto from(Place place) {
+        return new PlaceResponseDto(
+                place.getPlaceId(),
+                place.getPlaceName(),
+                place.getAddress(),
+                place.getTel(),
+                place.getLatitude().doubleValue(),
+                place.getLongitude().doubleValue()
+        );
+    }
+}

--- a/src/main/java/com/unear/admin/places/repository/PlaceRepository.java
+++ b/src/main/java/com/unear/admin/places/repository/PlaceRepository.java
@@ -2,6 +2,21 @@ package com.unear.admin.places.repository;
 
 import com.unear.admin.places.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
+    @Query(value = """
+    SELECT p.* FROM places p
+    JOIN unear_events e ON e.unear_event_id = :eventId
+    WHERE ST_DistanceSphere(
+        ST_MakePoint(p.longitude, p.latitude),
+        ST_MakePoint(e.longitude, e.latitude)
+    ) <= e.radius_meter
+    AND (p.unear_event_id IS NULL OR p.unear_event_id != :eventId)
+    """, nativeQuery = true)
+    List<Place> findPartnersWithinEventRadius(@Param("eventId") Long eventId);
+
 }

--- a/src/main/java/com/unear/admin/places/service/PlaceService.java
+++ b/src/main/java/com/unear/admin/places/service/PlaceService.java
@@ -1,7 +1,12 @@
 package com.unear.admin.places.service;
 
-import com.unear.admin.places.dto.PlaceRequestDto;
+import com.unear.admin.places.dto.requestdto.PlaceRequestDto;
+import com.unear.admin.places.dto.responsedto.PlaceResponseDto;
+
+import java.util.List;
 
 public interface PlaceService {
     void savePlace(Long eventId, PlaceRequestDto requestDto);
+    List<PlaceResponseDto> getPartnersWithinEvent(Long eventId);
+
 }

--- a/src/main/java/com/unear/admin/places/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/com/unear/admin/places/service/impl/PlaceServiceImpl.java
@@ -4,13 +4,16 @@ import com.unear.admin.event.entity.Event;
 import com.unear.admin.event.repository.EventRepository;
 import com.unear.admin.exception.BusinessException;
 import com.unear.admin.exception.ErrorCode;
-import com.unear.admin.places.dto.PlaceRequestDto;
+import com.unear.admin.places.dto.requestdto.PlaceRequestDto;
+import com.unear.admin.places.dto.responsedto.PlaceResponseDto;
 import com.unear.admin.places.entity.Place;
 import com.unear.admin.places.repository.PlaceRepository;
 import com.unear.admin.places.service.PlaceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -28,5 +31,13 @@ public class PlaceServiceImpl implements PlaceService {
         Place place = dto.toEntity(event); // 변환 책임은 DTO 내부
 
         placeRepository.save(place);
+    }
+
+    @Override
+    public List<PlaceResponseDto> getPartnersWithinEvent(Long eventId) {
+        List<Place> result = placeRepository.findPartnersWithinEventRadius(eventId);
+        return result.stream()
+                .map(PlaceResponseDto::from)
+                .toList();
     }
 }

--- a/src/main/java/com/unear/admin/places/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/com/unear/admin/places/service/impl/PlaceServiceImpl.java
@@ -35,6 +35,10 @@ public class PlaceServiceImpl implements PlaceService {
 
     @Override
     public List<PlaceResponseDto> getPartnersWithinEvent(Long eventId) {
+        // 이벤트 존재 여부 검증
+        eventRepository.findById(eventId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.EVENT_NOT_FOUND));
+        
         List<Place> result = placeRepository.findPartnersWithinEventRadius(eventId);
         return result.stream()
                 .map(PlaceResponseDto::from)


### PR DESCRIPTION
## PR 목적

- 어떤 기능을 **왜** 추가/수정했는지 목적 위주로 간단히 서술
- 코드래빗 요약 + 이 설명만으로도 맥락이 명확해야 함



## 변경 사항

[WL7-134]반경 내 제휴처 리스트 불러오기



## 주요 구현 내용

이벤트 아이디 받아온 후 해당 이벤트 지역 반경 내 제휴처 불러오기 기능 추가



## 테스트 및 동작 화면 (필요 시 첨부)

<img width="673" height="663" alt="image" src="https://github.com/user-attachments/assets/a382519f-80e8-42b1-9180-910535631d89" />




## 리뷰 시 중점적으로 봐야 할 부분

- 예 : 예외 처리 방식 적절한지 (`fromCode`)
- 예 : 등급 로직이 의도대로 잘 분리되었는지



## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [x] 코드래빗 리뷰 검토


[WL7-134]: https://lguplus20250120.atlassian.net/browse/WL7-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ