### PR TITLE
[WL7-71] 이벤트 등록시 필요한 Entity,Dto 수정 ( Update enums and DTOs for discount, place categories, and related fields )

### DIFF
--- a/src/main/java/com/unear/admin/common/enums/DiscountPolicy.java
+++ b/src/main/java/com/unear/admin/common/enums/DiscountPolicy.java
@@ -5,9 +5,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;
 
 public enum DiscountPolicy {
-    DISCOUNT("할인"),
-    POINT("적립"),
-    GIFT("증정"),
+    COUPON_FIXED("(쿠폰) 금액 할인"),
+    COUPON_PERCENT("(쿠폰) 퍼센트 할인"),
+    MEMBERSHIP_UNIT("(멤버십) 금액당 할인"),
+    MEMBERSHIP_FIXED("(멤버십) 금액 할인"),
     COUPON_FCFS("선착순 전용 쿠폰");
 
     private final String label;

--- a/src/main/java/com/unear/admin/common/enums/PlaceCategory.java
+++ b/src/main/java/com/unear/admin/common/enums/PlaceCategory.java
@@ -1,10 +1,15 @@
 package com.unear.admin.common.enums;
 
 public enum PlaceCategory {
-    FOOD("FOOD", "음식"),
-    LIFE("LIFE", "생활"),
-    BEAUTY("BEAUTY", "뷰티"),
-    HEALTH("HEALTH", "건강");
+    FOOD("FOOD", "푸드"),
+    LIFE("LIFE", "생활/편의"),
+    BEAUTY("BEAUTY", "뷰티/건강"),
+    ACTIVITY("ACTIVITY", "액티비티"),
+    EDUCATION("EDUCATION","교육"),
+    CULTURE("CULTURE", "문화/여가"),
+    BAKERY("BAKERY", "베이커리"),
+    SHOPPING("SHOPPING", "쇼핑"),
+    CAFE("CAFE", "카페");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/unear/admin/common/enums/PlaceType.java
+++ b/src/main/java/com/unear/admin/common/enums/PlaceType.java
@@ -1,9 +1,10 @@
 package com.unear.admin.common.enums;
 
 public enum PlaceType {
-    GENERAL("GENERAL", "일반 마커"),
-    FRANCHISE("FRANCHISE", "프랜차이즈 마커"),
-    POPUP("POPUP","팝업스토어");
+    GENERAL("BASIC", "기본혜택"),
+    FRANCHISE("FRANCHISE", "프랜차이즈"),
+    POPUP("POPUP","팝업스토어"),
+    LOCAL("LOCAL", "우리동네멤버십");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/unear/admin/common/enums/PlaceType.java
+++ b/src/main/java/com/unear/admin/common/enums/PlaceType.java
@@ -1,7 +1,7 @@
 package com.unear.admin.common.enums;
 
 public enum PlaceType {
-    GENERAL("BASIC", "기본혜택"),
+    BASIC("BASIC", "기본혜택"),
     FRANCHISE("FRANCHISE", "프랜차이즈"),
     POPUP("POPUP","팝업스토어"),
     LOCAL("LOCAL", "우리동네멤버십");

--- a/src/main/java/com/unear/admin/coupon/dto/CouponTemplateRequestDto.java
+++ b/src/main/java/com/unear/admin/coupon/dto/CouponTemplateRequestDto.java
@@ -16,22 +16,28 @@ public class CouponTemplateRequestDto {
 
     private String couponName;
     private String description;
+
     @Builder.Default
     private DiscountPolicy discountPolicy = DiscountPolicy.COUPON_FCFS;
+
     private Integer remainingQuantity;
 
     private LocalDate couponStart;
     private LocalDate couponEnd;
 
+    private String markerCode;
+    private String membershipCode;
+
     public CouponTemplate toEntity(Event event) {
         return CouponTemplate.builder()
                 .couponName(couponName)
                 .description(description)
-                .discountCode(discountPolicy.name())
-                .discountPolicy(discountPolicy.getLabel())
+                .discountPolicy(discountPolicy)
                 .remainingQuantity(remainingQuantity)
                 .couponStart(couponStart)
                 .couponEnd(couponEnd)
+                .markerCode(markerCode)
+                .membershipCode(membershipCode)
                 .event(event)
                 .build();
     }

--- a/src/main/java/com/unear/admin/coupon/dto/CouponTemplateRequestDto.java
+++ b/src/main/java/com/unear/admin/coupon/dto/CouponTemplateRequestDto.java
@@ -1,6 +1,6 @@
 package com.unear.admin.coupon.dto;
 
-import com.unear.admin.common.enums.DiscountPolicy;
+
 import com.unear.admin.coupon.entity.CouponTemplate;
 import com.unear.admin.event.entity.Event;
 import lombok.*;
@@ -15,10 +15,6 @@ import java.time.LocalDate;
 public class CouponTemplateRequestDto {
 
     private String couponName;
-    private String description;
-
-    @Builder.Default
-    private DiscountPolicy discountPolicy = DiscountPolicy.COUPON_FCFS;
 
     private Integer remainingQuantity;
 
@@ -31,8 +27,6 @@ public class CouponTemplateRequestDto {
     public CouponTemplate toEntity(Event event) {
         return CouponTemplate.builder()
                 .couponName(couponName)
-                .description(description)
-                .discountPolicy(discountPolicy)
                 .remainingQuantity(remainingQuantity)
                 .couponStart(couponStart)
                 .couponEnd(couponEnd)

--- a/src/main/java/com/unear/admin/coupon/entity/CouponTemplate.java
+++ b/src/main/java/com/unear/admin/coupon/entity/CouponTemplate.java
@@ -1,5 +1,6 @@
 package com.unear.admin.coupon.entity;
 
+import com.unear.admin.common.enums.DiscountPolicy;
 import com.unear.admin.event.entity.Event;
 import jakarta.persistence.*;
 import lombok.*;
@@ -7,11 +8,11 @@ import lombok.*;
 import java.time.LocalDate;
 
 @Entity
+@Table(name = "coupon_templates")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "coupon_templates")
 public class CouponTemplate {
 
     @Id
@@ -23,14 +24,24 @@ public class CouponTemplate {
     private Event event;
 
     private String couponName;
-    private String description;
-    private String discountCode;
 
-    private String discountPolicy;
+    @Column(length = 255)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "discount_code")
+    private DiscountPolicy discountPolicy;
+
     private Integer remainingQuantity;
 
     private LocalDate couponStart;
     private LocalDate couponEnd;
+
+    @Column(name = "marker_code")
+    private String markerCode;
+
+    @Column(name = "membership_code")
+    private String membershipCode;
 
     public void setEvent(Event event) {
         this.event = event;

--- a/src/main/java/com/unear/admin/coupon/entity/CouponTemplate.java
+++ b/src/main/java/com/unear/admin/coupon/entity/CouponTemplate.java
@@ -25,9 +25,6 @@ public class CouponTemplate {
 
     private String couponName;
 
-    @Column(length = 255)
-    private String description;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "discount_code")
     private DiscountPolicy discountPolicy;

--- a/src/main/java/com/unear/admin/coupon/service/impl/CouponTemplateServiceImpl.java
+++ b/src/main/java/com/unear/admin/coupon/service/impl/CouponTemplateServiceImpl.java
@@ -1,7 +1,6 @@
 package com.unear.admin.coupon.service.impl;
 
 import com.unear.admin.coupon.dto.CouponTemplateRequestDto;
-import com.unear.admin.coupon.entity.CouponTemplate;
 import com.unear.admin.coupon.repository.CouponTemplateRepository;
 import com.unear.admin.coupon.service.CouponTemplateService;
 import com.unear.admin.event.entity.Event;
@@ -24,17 +23,7 @@ public class CouponTemplateServiceImpl implements CouponTemplateService {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.EVENT_NOT_FOUND));
 
-        CouponTemplate coupon = CouponTemplate.builder()
-                .event(event)
-                .couponName(dto.getCouponName())
-                .description(dto.getDescription())
-                .discountPolicy(dto.getDiscountPolicy().getLabel())
-                .remainingQuantity(dto.getRemainingQuantity())
-                .couponStart(dto.getCouponStart())
-                .couponEnd(dto.getCouponEnd())
-                .build();
-
-        couponTemplateRepository.save(coupon);
+        couponTemplateRepository.save(dto.toEntity(event));
     }
 
 

--- a/src/main/java/com/unear/admin/places/controller/PlaceController.java
+++ b/src/main/java/com/unear/admin/places/controller/PlaceController.java
@@ -5,6 +5,7 @@ import com.unear.admin.places.dto.requestdto.PlaceRequestDto;
 import com.unear.admin.places.dto.responsedto.PlaceResponseDto;
 import com.unear.admin.places.service.PlaceService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/unear/admin/places/dto/requestdto/PlaceRequestDto.java
+++ b/src/main/java/com/unear/admin/places/dto/requestdto/PlaceRequestDto.java
@@ -2,7 +2,6 @@ package com.unear.admin.places.dto.requestdto;
 
 import com.unear.admin.common.enums.PlaceCategory;
 import com.unear.admin.common.enums.PlaceType;
-import com.unear.admin.common.enums.DiscountPolicy;
 import com.unear.admin.event.entity.Event;
 import com.unear.admin.places.entity.Place;
 import lombok.*;
@@ -17,32 +16,39 @@ import java.math.BigDecimal;
 public class PlaceRequestDto {
 
     private String placeName;
-    private String placeDescription;
+    private String placeDesc;
     private String address;
     private String tel;
 
     private BigDecimal latitude;
     private BigDecimal longitude;
 
-    private String startTime; // UI 입력값
-    private String endTime;
+    private String benefitCategory;
+    private Integer startTime;
+    private Integer endTime;
 
-    private PlaceType markerCode;
     private PlaceCategory categoryCode;
-    private DiscountPolicy benefitCategory;
+    private PlaceType markerCode;
 
+    private String eventCode;
     private Long franchiseId;
 
     public Place toEntity(Event event) {
         return Place.builder()
                 .placeName(placeName)
-                .placeDesc(placeDescription)
+                .placeDesc(placeDesc)
                 .address(address)
                 .tel(tel)
                 .latitude(latitude)
                 .longitude(longitude)
-                .startTime(parseTime(startTime))
-                .endTime(parseTime(endTime))
+                .benefitCategory(benefitCategory)
+                .startTime(startTime)
+                .endTime(endTime)
+                .categoryCode(categoryCode)
+                .markerCode(markerCode)
+                .eventCode(eventCode)
+                .franchiseId(franchiseId)
+                .event(event)
                 .build();
     }
 

--- a/src/main/java/com/unear/admin/places/entity/Place.java
+++ b/src/main/java/com/unear/admin/places/entity/Place.java
@@ -1,5 +1,7 @@
 package com.unear.admin.places.entity;
 
+import com.unear.admin.common.enums.PlaceCategory;
+import com.unear.admin.common.enums.PlaceType;
 import com.unear.admin.event.entity.Event;
 import jakarta.persistence.*;
 import lombok.*;
@@ -18,26 +20,34 @@ public class Place {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long placeId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "unear_event_id")
-    private Event event;
-
     private String placeName;
     private String placeDesc;
     private String address;
+    private String tel;
 
-    @Column(precision = 10, scale = 7)
     private BigDecimal latitude;
-
-    @Column(precision = 10, scale = 7)
     private BigDecimal longitude;
 
+    @Column(name = "benefit_category")
+    private String benefitCategory;
 
     private Integer startTime;
     private Integer endTime;
 
-    private String tel;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category_code")
+    private PlaceCategory categoryCode;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "marker_code")
+    private PlaceType markerCode;
+
+    private String eventCode;
+    private Long franchiseId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "unear_event_id")
+    private Event event;
 
     public void setEvent(Event event) {
         this.event = event;

--- a/src/main/java/com/unear/admin/places/entity/Place.java
+++ b/src/main/java/com/unear/admin/places/entity/Place.java
@@ -25,7 +25,10 @@ public class Place {
     private String address;
     private String tel;
 
+    @Column(precision = 10, scale = 7)
     private BigDecimal latitude;
+
+    @Column(precision = 10, scale = 7)
     private BigDecimal longitude;
 
     @Column(name = "benefit_category")


### PR DESCRIPTION
## PR 목적

프로젝트 빌드시 잘못된 엔티티 생성으로 인하여 데이터베이스 잘못된 컬럼이 생김, 해당 로직 변경


## 변경 사항

- [WL7-71] 이벤트 등록시에 데이터베이스에 쓸모없는 컬럼 추가되는 코드 수정



## 주요 구현 내용

Entity 컬럼명 붙히기, enum 파일 수정



## 테스트 및 동작 화면 (필요 시 첨부)

### unear_event 테이블
<img width="1250" height="222" alt="image" src="https://github.com/user-attachments/assets/295d1598-5edf-4e70-9466-05f813d2da39" />

### place 테이블
<img width="1657" height="79" alt="image" src="https://github.com/user-attachments/assets/2db48d26-0051-4928-ba89-d467dd43757b" />

### coupon_template 테이블
<img width="1629" height="323" alt="image" src="https://github.com/user-attachments/assets/9eaee53d-7182-4f74-811e-ac8af4874fd7" />



## 리뷰 시 중점적으로 봐야 할 부분




## 병합 전 체크리스트

- [x] 로컬 테스트 완료
- [x] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [x] 코드래빗 리뷰 검토


[WL7-71]: https://lguplus20250120.atlassian.net/browse/WL7-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ