### PR TITLE
[WL7-312]불필요한 컬럼 삭제 및 이벤트 생성 관련 코드 수정 ( Refactor event-place relationship to use EventPlace mapping entity and EventType enum )

### DIFF
--- a/src/main/java/com/unear/admin/common/enums/EventType.java
+++ b/src/main/java/com/unear/admin/common/enums/EventType.java
@@ -1,0 +1,14 @@
+package com.unear.admin.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EventType {
+    NONE("이벤트 아님"),
+    GENERAL("이벤트(일반)"),
+    REQUIRE("이벤트(필수)");
+
+    private final String label;
+}

--- a/src/main/java/com/unear/admin/event/controller/EventController.java
+++ b/src/main/java/com/unear/admin/event/controller/EventController.java
@@ -1,9 +1,11 @@
 package com.unear.admin.event.controller;
 
+import com.unear.admin.common.response.ApiResponse;
 import com.unear.admin.coupon.dto.request.CouponTemplateRequestDto;
+import com.unear.admin.event.dto.request.EventPlaceRegistrationRequest;
 import com.unear.admin.event.dto.request.EventRequestDto;
 import com.unear.admin.event.service.EventService;
-import com.unear.admin.places.dto.requestdto.PlaceRequestDto;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +17,7 @@ public class EventController {
 
     private final EventService eventService;
 
+
     @PostMapping
     public ResponseEntity<Long> registerBaseEvent(@RequestBody EventRequestDto eventDto) {
         Long eventId = eventService.createBaseEvent(eventDto);
@@ -22,10 +25,12 @@ public class EventController {
     }
 
     @PostMapping("/{eventId}/places")
-    public ResponseEntity<Void> registerPlace(@PathVariable Long eventId,
-                                              @RequestBody PlaceRequestDto placeDto) {
-        eventService.addPlaceToEvent(eventId, placeDto);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<ApiResponse<String>> registerPopupAndPartners(
+            @PathVariable Long eventId,
+            @RequestBody EventPlaceRegistrationRequest request
+    ) {
+        eventService.registerPopupAndPartners(eventId, request);
+        return ResponseEntity.ok(ApiResponse.success("팝업스토어 및 제휴처 등록 완료"));
     }
 
     @PostMapping("/{eventId}/coupon")

--- a/src/main/java/com/unear/admin/event/dto/request/EventPlaceRegistrationRequest.java
+++ b/src/main/java/com/unear/admin/event/dto/request/EventPlaceRegistrationRequest.java
@@ -1,0 +1,9 @@
+package com.unear.admin.event.dto.request;
+
+import com.unear.admin.places.dto.requestdto.PlaceRequestDto;
+import java.util.List;
+
+public record EventPlaceRegistrationRequest(
+        PlaceRequestDto popupStore,
+        List<Long> partnerPlaceIds
+) {}

--- a/src/main/java/com/unear/admin/event/dto/response/EventDetailResponseDto.java
+++ b/src/main/java/com/unear/admin/event/dto/response/EventDetailResponseDto.java
@@ -24,12 +24,7 @@ public record EventDetailResponseDto(
         List<PlaceResponseDto> partnerStores,
         List<CouponTemplateResponseDto> coupons
 ) {
-    public static EventDetailResponseDto from(Event event, List<Place> partners, List<CouponTemplate> templates) {
-        Place popupStore = event.getPlaces().stream()
-            .filter(p -> p.getEvent() != null)
-            .findFirst()
-            .orElse(null);
-            
+    public static EventDetailResponseDto from(Event event, Place popupStore, List<Place> partners, List<CouponTemplate> templates) {
         return EventDetailResponseDto.builder()
                 .eventId(event.getUnearEventsId())
                 .eventName(event.getEventName())
@@ -39,9 +34,10 @@ public record EventDetailResponseDto(
                 .radius(event.getRadiusMeter())
                 .startDate(event.getStartAt())
                 .endDate(event.getEndAt())
-                .popupStore(event.getPlaces().isEmpty() ? null : PlaceResponseDto.from(event.getPlaces().get(0)))
+                .popupStore(popupStore != null ? PlaceResponseDto.from(popupStore) : null)
                 .partnerStores(partners.stream().map(PlaceResponseDto::from).toList())
                 .coupons(templates.stream().map(CouponTemplateResponseDto::from).toList())
                 .build();
     }
+
 }

--- a/src/main/java/com/unear/admin/event/entity/Event.java
+++ b/src/main/java/com/unear/admin/event/entity/Event.java
@@ -2,14 +2,11 @@ package com.unear.admin.event.entity;
 
 import com.unear.admin.coupon.entity.CouponTemplate;
 import com.unear.admin.event.dto.request.EventRequestDto;
-import com.unear.admin.places.entity.Place;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -39,15 +36,6 @@ public class Event {
 
     @OneToOne(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
     private CouponTemplate couponTemplate;
-
-    @Builder.Default
-    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Place> places = new ArrayList<>();
-
-    public void addPlace(Place place) {
-        this.places.add(place);
-        place.setEvent(this);
-    }
 
     public void setCouponTemplate(CouponTemplate couponTemplate) {
         this.couponTemplate = couponTemplate;

--- a/src/main/java/com/unear/admin/event/service/EventService.java
+++ b/src/main/java/com/unear/admin/event/service/EventService.java
@@ -1,6 +1,7 @@
 package com.unear.admin.event.service;
 
 import com.unear.admin.coupon.dto.request.CouponTemplateRequestDto;
+import com.unear.admin.event.dto.request.EventPlaceRegistrationRequest;
 import com.unear.admin.event.dto.request.EventRequestDto;
 import com.unear.admin.places.dto.requestdto.PlaceRequestDto;
 
@@ -8,7 +9,8 @@ public interface EventService {
 
     Long createBaseEvent(EventRequestDto dto);
 
-    void addPlaceToEvent(Long eventId, PlaceRequestDto dto);
 
     void addCouponToEvent(Long eventId, CouponTemplateRequestDto dto);
+
+    void registerPopupAndPartners(Long eventId, EventPlaceRegistrationRequest request);
 }

--- a/src/main/java/com/unear/admin/event/service/impl/UnearEventServiceImpl.java
+++ b/src/main/java/com/unear/admin/event/service/impl/UnearEventServiceImpl.java
@@ -1,11 +1,15 @@
 package com.unear.admin.event.service.impl;
 
+import com.unear.admin.common.enums.EventType;
 import com.unear.admin.coupon.dto.request.CouponTemplateRequestDto;
 import com.unear.admin.coupon.entity.CouponTemplate;
 import com.unear.admin.coupon.repository.CouponTemplateRepository;
 import com.unear.admin.event.dto.request.EventRequestDto;
+import com.unear.admin.event.dto.request.EventPlaceRegistrationRequest;
 import com.unear.admin.event.entity.Event;
 import com.unear.admin.event.repository.EventRepository;
+import com.unear.admin.eventplace.entity.EventPlace;
+import com.unear.admin.eventplace.repository.EventPlaceRepository;
 import com.unear.admin.event.service.EventService;
 import com.unear.admin.places.dto.requestdto.PlaceRequestDto;
 import com.unear.admin.places.entity.Place;
@@ -14,6 +18,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -21,6 +27,7 @@ public class UnearEventServiceImpl implements EventService {
 
     private final EventRepository eventRepository;
     private final PlaceRepository placeRepository;
+    private final EventPlaceRepository eventPlaceRepository;
     private final CouponTemplateRepository couponTemplateRepository;
 
     @Override
@@ -30,18 +37,46 @@ public class UnearEventServiceImpl implements EventService {
     }
 
     @Override
-    public void addPlaceToEvent(Long eventId, PlaceRequestDto dto) {
-        Event event = eventRepository.findById(eventId)
-                .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다."));
-        Place place = dto.toEntity(event);
-        placeRepository.save(place);
-    }
-
-    @Override
     public void addCouponToEvent(Long eventId, CouponTemplateRequestDto dto) {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다."));
         CouponTemplate coupon = dto.toEntity(event);
         couponTemplateRepository.save(coupon);
     }
+
+    @Override
+    public void registerPopupAndPartners(Long eventId, EventPlaceRegistrationRequest request) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다."));
+
+        // 1. 팝업스토어 저장 및 이벤트 등록
+        PlaceRequestDto popupDto = request.popupStore();
+        popupDto.setEventCode(EventType.REQUIRE);
+        Place popupPlace = popupDto.toEntity();
+        placeRepository.save(popupPlace);
+
+        EventPlace popupMapping = EventPlace.builder()
+                .event(event)
+                .place(popupPlace)
+                .eventCode(EventType.REQUIRE)
+                .build();
+        eventPlaceRepository.save(popupMapping);
+
+        // 2. 제휴처 저장 및 이벤트 등록
+        List<Long> partnerIds = request.partnerPlaceIds();
+        for (Long partnerId : partnerIds) {
+            Place partner = placeRepository.findById(partnerId)
+                    .orElseThrow(() -> new IllegalArgumentException("제휴처가 존재하지 않습니다. ID: " + partnerId));
+
+            partner.setEventCode(EventType.GENERAL); // 💡 자동 분기
+
+            EventPlace partnerMapping = EventPlace.builder()
+                    .event(event)
+                    .place(partner)
+                    .eventCode(EventType.GENERAL)
+                    .build();
+            eventPlaceRepository.save(partnerMapping);
+        }
+    }
+
 }

--- a/src/main/java/com/unear/admin/eventplace/dto/request/EventPlaceRequestDto.java
+++ b/src/main/java/com/unear/admin/eventplace/dto/request/EventPlaceRequestDto.java
@@ -1,6 +1,8 @@
 package com.unear.admin.eventplace.dto.request;
 
 
+import com.unear.admin.common.enums.EventType;
+import com.unear.admin.common.enums.PlaceCategory;
 import com.unear.admin.event.entity.Event;
 import com.unear.admin.eventplace.entity.EventPlace;
 import com.unear.admin.places.entity.Place;
@@ -15,7 +17,7 @@ public class EventPlaceRequestDto {
 
     private Long eventId;
     private Long placeId;
-    private String eventCode;
+    private EventType eventCode;
 
     public EventPlace toEntity(Event event, Place place) {
         return EventPlace.builder()

--- a/src/main/java/com/unear/admin/eventplace/entity/EventPlace.java
+++ b/src/main/java/com/unear/admin/eventplace/entity/EventPlace.java
@@ -1,5 +1,7 @@
 package com.unear.admin.eventplace.entity;
 
+import com.unear.admin.common.enums.EventType;
+import com.unear.admin.common.enums.PlaceCategory;
 import com.unear.admin.event.entity.Event;
 import com.unear.admin.places.entity.Place;
 import jakarta.persistence.*;
@@ -27,6 +29,7 @@ public class EventPlace {
     @JoinColumn(name = "place_id", nullable = false)
     private Place place;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "event_code")
-    private String eventCode;
+    private EventType eventCode;
 }

--- a/src/main/java/com/unear/admin/places/dto/requestdto/PlaceRequestDto.java
+++ b/src/main/java/com/unear/admin/places/dto/requestdto/PlaceRequestDto.java
@@ -4,6 +4,8 @@ import com.unear.admin.common.enums.PlaceCategory;
 import com.unear.admin.common.enums.PlaceType;
 import com.unear.admin.event.entity.Event;
 import com.unear.admin.places.entity.Place;
+import com.unear.admin.common.enums.EventType;
+
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -32,10 +34,10 @@ public class PlaceRequestDto {
     private PlaceCategory categoryCode;
     private PlaceType markerCode;
 
-    private String eventCode;
+    private EventType eventCode = EventType.NONE;
     private Long franchiseId;
 
-    public Place toEntity(Event event) {
+    public Place toEntity() {
         return Place.builder()
                 .placeName(placeName)
                 .placeDesc(placeDesc)
@@ -50,7 +52,6 @@ public class PlaceRequestDto {
                 .markerCode(markerCode)
                 .eventCode(eventCode)
                 .franchiseId(franchiseId)
-                .event(event)
                 .build();
     }
 

--- a/src/main/java/com/unear/admin/places/entity/Place.java
+++ b/src/main/java/com/unear/admin/places/entity/Place.java
@@ -1,8 +1,9 @@
 package com.unear.admin.places.entity;
 
+import com.unear.admin.common.enums.EventType;
 import com.unear.admin.common.enums.PlaceCategory;
 import com.unear.admin.common.enums.PlaceType;
-import com.unear.admin.event.entity.Event;
+
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -46,22 +47,17 @@ public class Place {
     @Column(name = "marker_code")
     private PlaceType markerCode;
 
-    private String eventCode;
     private Long franchiseId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "unear_event_id")
-    private Event event;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type_code", nullable = false)
+    private EventType eventCode = EventType.NONE;
 
-    public void setEvent(Event event) {
-        this.event = event;
-    }
-    
     public void updatePlaceInfo(String placeName, String placeDesc, String address,
                                 String tel, BigDecimal latitude, BigDecimal longitude,
                                 String benefitCategory, Integer startTime, Integer endTime,
                                 PlaceCategory categoryCode, PlaceType markerCode,
-                                String eventCode, Long franchiseId) {
+                                EventType eventCode, Long franchiseId) {
         this.placeName = placeName;
         this.placeDesc = placeDesc;
         this.address = address;
@@ -76,5 +72,4 @@ public class Place {
         this.eventCode = eventCode;
         this.franchiseId = franchiseId;
     }
-
 }

--- a/src/main/java/com/unear/admin/places/repository/PlaceRepository.java
+++ b/src/main/java/com/unear/admin/places/repository/PlaceRepository.java
@@ -15,8 +15,10 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
         ST_MakePoint(p.longitude, p.latitude),
         ST_MakePoint(e.longitude, e.latitude)
     ) <= e.radius_meter
-    AND (p.unear_event_id IS NULL OR p.unear_event_id != :eventId)
-    """, nativeQuery = true)
+    AND p.place_id NOT IN (
+        SELECT ep.place_id FROM event_places ep WHERE ep.unear_event_id = :eventId
+    )
+""", nativeQuery = true)
     List<Place> findPartnersWithinEventRadius(@Param("eventId") Long eventId);
 
 }

--- a/src/main/java/com/unear/admin/places/service/impl/PlaceServiceImpl.java
+++ b/src/main/java/com/unear/admin/places/service/impl/PlaceServiceImpl.java
@@ -67,9 +67,10 @@ public class PlaceServiceImpl implements PlaceService {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.EVENT_NOT_FOUND));
 
-        // 팝업스토어의 경우 프랜차이즈 ID 제거
+        // 팝업스토어는 독립적인 매장으로 프랜차이즈에 속하지 않음
+        Place place = dto.toEntity();
         if (dto.getEventCode() == EventType.REQUIRE) {
-            dto.setFranchiseId(null);
+            place.setFranchiseId(null);
         }
 
         Place place = dto.toEntity();


### PR DESCRIPTION
## PR 목적

불필요한 컬럼 삭제



## 변경 사항

#17 #18 
팝업스토어 , 이벤트 지역 반경 내 제휴처들 따로 postman 으로 넣었는데
팝업스토어, 베휴처들 같이 넣음
순서 : 이벤트 생성 -> 이벤트 반경 조회 -> 팝업스토어,제휴처 선정 -> 선착순 쿠폰 생성


## 주요 구현 내용

전체적인 entity, serviceImpl 리펙터



## 테스트 및 동작 화면 (필요 시 첨부)
<img width="611" height="582" alt="image" src="https://github.com/user-attachments/assets/17a84235-0556-4c41-bb1b-902d36eabcad" />

<img width="789" height="664" alt="image" src="https://github.com/user-attachments/assets/d3ddc9e9-0eb6-4695-8a7b-0fe7c0b454e6" />

<img width="898" height="775" alt="image" src="https://github.com/user-attachments/assets/bb83429a-1c64-49c5-8618-a57af72f6678" />

<img width="706" height="721" alt="image" src="https://github.com/user-attachments/assets/d2fcd153-2b57-4b45-850b-225d68cb53c4" />



## 리뷰 시 중점적으로 봐야 할 부분



## 병합 전 체크리스트

- [x] 로컬 테스트 완료
- [x] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [x] 코드래빗 리뷰 검토
