### PR TITLE
[WL7-335] 쿠폰 crud 추가 ( Add coupon template CRUD API with validation and update REST endpoints )

### DIFF
--- a/src/main/java/com/unear/admin/common/enums/PlaceType.java
+++ b/src/main/java/com/unear/admin/common/enums/PlaceType.java
@@ -3,8 +3,8 @@ package com.unear.admin.common.enums;
 public enum PlaceType {
     BASIC("BASIC", "기본혜택"),
     FRANCHISE("FRANCHISE", "프랜차이즈"),
-    POPUP("POPUP","팝업스토어"),
-    LOCAL("LOCAL", "우리동네멤버십");
+    POPUP("POPUP","팝업스토어");
+//    LOCAL("LOCAL", "우리동네멤버십");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/unear/admin/coupon/controller/CouponTemplateController.java
+++ b/src/main/java/com/unear/admin/coupon/controller/CouponTemplateController.java
@@ -1,11 +1,14 @@
 package com.unear.admin.coupon.controller;
 
-import com.unear.admin.common.docs.coupontemplate.CouponTemplateApiDocs;
 import com.unear.admin.coupon.dto.request.CouponTemplateRequestDto;
+import com.unear.admin.coupon.dto.response.CouponTemplateResponseDto;
 import com.unear.admin.coupon.service.CouponTemplateService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RestController
@@ -15,11 +18,33 @@ public class CouponTemplateController {
 
     private final CouponTemplateService couponTemplateService;
 
-//    @CouponTemplateApiDocs.PostCouponTemplate
-//    @PostMapping("/{eventId}/coupon")
-//    public ResponseEntity<Void> registerCoupon(@PathVariable Long eventId,
-//                                               @RequestBody CouponTemplateRequestDto couponDto) {
-//        couponTemplateService.saveCouponTemplate(eventId, couponDto);
-//        return ResponseEntity.ok().build();
-//    }
+    @PostMapping    //create
+    public ResponseEntity<?> createGeneralCoupon(@RequestBody @Valid CouponTemplateRequestDto dto) {
+        couponTemplateService.createGeneralCoupon(dto);
+        return ResponseEntity.ok("일반 쿠폰 생성 완료");
+    }
+
+    @GetMapping     //read
+    public ResponseEntity<List<CouponTemplateResponseDto>> getAllCoupons() {
+        return ResponseEntity.ok(couponTemplateService.getAllCoupons());
+    }
+
+    @GetMapping("/{id}")    //detail read
+    public ResponseEntity<CouponTemplateResponseDto> getCoupon(@PathVariable Long id) {
+        return ResponseEntity.ok(couponTemplateService.getCoupon(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<String> updateCoupon(@PathVariable Long id, @RequestBody @Valid CouponTemplateRequestDto dto) {
+        couponTemplateService.updateCoupon(id, dto);
+        return ResponseEntity.ok("쿠폰이 성공적으로 수정되었습니다.");
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteCoupon(@PathVariable Long id) {
+        couponTemplateService.deleteCoupon(id);
+        return ResponseEntity.ok("쿠폰이 성공적으로 삭제되었습니다.");
+    }
+
+
 }

--- a/src/main/java/com/unear/admin/coupon/dto/request/CouponTemplateRequestDto.java
+++ b/src/main/java/com/unear/admin/coupon/dto/request/CouponTemplateRequestDto.java
@@ -6,6 +6,8 @@ import com.unear.admin.common.enums.MembershipGrade;
 import com.unear.admin.common.enums.PlaceType;
 import com.unear.admin.coupon.entity.CouponTemplate;
 import com.unear.admin.event.entity.Event;
+import com.unear.admin.exception.BusinessException;
+import com.unear.admin.exception.ErrorCode;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -19,14 +21,17 @@ public class CouponTemplateRequestDto {
 
     private String couponName;
 
+    private Long discountPolicyId;
     private Integer remainingQuantity;
 
     private LocalDate couponStart;
     private LocalDate couponEnd;
 
     private DiscountPolicy discountCode;
+
     private PlaceType markerCode;
     private MembershipGrade membershipCode;
+
 
     public CouponTemplate toEntity(Event event) {
         return CouponTemplate.builder()
@@ -37,7 +42,29 @@ public class CouponTemplateRequestDto {
                 .discountCode(discountCode)
                 .markerCode(markerCode)
                 .membershipCode(membershipCode)
+                .discountPolicyDetailId(discountPolicyId)
                 .event(event)
                 .build();
+    }
+
+    public void updateEntity(CouponTemplate entity) {
+        if (discountCode == DiscountPolicy.COUPON_FCFS) {
+            throw new BusinessException(ErrorCode.INVALID_COUPON_POLICY);
+        }
+
+        if (discountPolicyId == null) {
+            throw new BusinessException(ErrorCode.INVALID_COUPON_POLICY);
+        }
+
+        entity.update(
+                couponName,
+                discountCode,
+                remainingQuantity,
+                couponStart,
+                couponEnd,
+                membershipCode,
+                markerCode,
+                discountPolicyId
+        );
     }
 }

--- a/src/main/java/com/unear/admin/coupon/entity/CouponTemplate.java
+++ b/src/main/java/com/unear/admin/coupon/entity/CouponTemplate.java
@@ -26,9 +26,9 @@ public class CouponTemplate {
     private Event event;
 
     private String couponName;
+    private Long discountPolicyDetailId;
 
     @Enumerated(EnumType.STRING)
-
     @Column(name = "discount_code")
     private DiscountPolicy discountCode;
 
@@ -47,5 +47,19 @@ public class CouponTemplate {
 
     public void setEvent(Event event) {
         this.event = event;
+    }
+
+    public void update(String couponName, DiscountPolicy discountCode, Integer remainingQuantity,
+                       LocalDate couponStart, LocalDate couponEnd,
+                       MembershipGrade membershipCode, PlaceType markerCode, Long discountPolicyDetailId) {
+
+        this.couponName = couponName;
+        this.discountCode = discountCode;
+        this.remainingQuantity = remainingQuantity;
+        this.couponStart = couponStart;
+        this.couponEnd = couponEnd;
+        this.membershipCode = membershipCode;
+        this.markerCode = markerCode;
+        this.discountPolicyDetailId = discountPolicyDetailId;
     }
 }

--- a/src/main/java/com/unear/admin/coupon/service/CouponTemplateService.java
+++ b/src/main/java/com/unear/admin/coupon/service/CouponTemplateService.java
@@ -1,7 +1,19 @@
 package com.unear.admin.coupon.service;
 
 import com.unear.admin.coupon.dto.request.CouponTemplateRequestDto;
+import com.unear.admin.coupon.dto.response.CouponTemplateResponseDto;
+
+import java.util.List;
 
 public interface CouponTemplateService {
     void saveCouponTemplate(Long eventId, CouponTemplateRequestDto dto);
+    void createGeneralCoupon(CouponTemplateRequestDto dto);
+
+    // 이후 구현할 기능들
+    List<CouponTemplateResponseDto> getAllCoupons();
+    CouponTemplateResponseDto getCoupon(Long id);
+    void updateCoupon(Long id, CouponTemplateRequestDto dto);
+    void deleteCoupon(Long id);
+
+
 }

--- a/src/main/java/com/unear/admin/coupon/service/impl/CouponTemplateServiceImpl.java
+++ b/src/main/java/com/unear/admin/coupon/service/impl/CouponTemplateServiceImpl.java
@@ -1,6 +1,10 @@
 package com.unear.admin.coupon.service.impl;
 
+import com.unear.admin.common.enums.DiscountPolicy;
+import com.unear.admin.common.enums.PlaceType;
 import com.unear.admin.coupon.dto.request.CouponTemplateRequestDto;
+import com.unear.admin.coupon.dto.response.CouponTemplateResponseDto;
+import com.unear.admin.coupon.entity.CouponTemplate;
 import com.unear.admin.coupon.repository.CouponTemplateRepository;
 import com.unear.admin.coupon.service.CouponTemplateService;
 import com.unear.admin.event.entity.Event;
@@ -10,12 +14,74 @@ import com.unear.admin.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class CouponTemplateServiceImpl implements CouponTemplateService {
 
     private final CouponTemplateRepository couponTemplateRepository;
     private final EventRepository eventRepository;
+
+    @Override   //create
+    public void createGeneralCoupon(CouponTemplateRequestDto dto) {
+        if (dto.getDiscountCode() == DiscountPolicy.COUPON_FCFS) {
+            throw new BusinessException(ErrorCode.INVALID_COUPON_POLICY); // 선착순은 허용하지 않음
+        }
+
+        if (dto.getDiscountPolicyId() == null) {
+            throw new BusinessException(ErrorCode.INVALID_COUPON_POLICY);
+        }
+
+        CouponTemplate entity = dto.toEntity(null); // 일반 쿠폰이므로 이벤트 없음
+        couponTemplateRepository.save(entity);
+    }
+
+    @Override   //read
+    public List<CouponTemplateResponseDto> getAllCoupons() {
+        return couponTemplateRepository.findAll().stream()
+                .map(CouponTemplateResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    @Override       //detail read
+    public CouponTemplateResponseDto getCoupon(Long id) {
+        CouponTemplate coupon = couponTemplateRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
+
+        if (coupon.getDiscountCode().equals(DiscountPolicy.COUPON_FCFS.name())) {
+            throw new BusinessException(ErrorCode.INVALID_COUPON_POLICY); // 선착순은 조회 불가
+        }
+
+        return CouponTemplateResponseDto.from(coupon);
+    }
+
+    @Override   //update
+    public void updateCoupon(Long id, CouponTemplateRequestDto dto) {
+        CouponTemplate coupon = couponTemplateRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
+
+        if (coupon.getDiscountCode() == DiscountPolicy.COUPON_FCFS) {
+            throw new BusinessException(ErrorCode.INVALID_COUPON_POLICY);
+        }
+
+        dto.updateEntity(coupon);
+    }
+
+
+    @Override   //
+    public void deleteCoupon(Long id) {
+        CouponTemplate coupon = couponTemplateRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.COUPON_NOT_FOUND));
+
+        // 선착순 쿠폰이면 삭제 금지
+        if (coupon.getDiscountCode() == DiscountPolicy.COUPON_FCFS) {
+            throw new BusinessException(ErrorCode.INVALID_COUPON_POLICY);
+        }
+
+        couponTemplateRepository.delete(coupon);
+    }
 
 
     @Override

--- a/src/main/java/com/unear/admin/exception/ErrorCode.java
+++ b/src/main/java/com/unear/admin/exception/ErrorCode.java
@@ -15,7 +15,10 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "서버 오류가 발생했습니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST,"INVALID_REQUEST", "요청이 유효하지 않습니다."),
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE_NOT_FOUND", "제휴처 정보를 찾을 수 없습니다."),
-    PLACE_ID_REQUIRED_FOR_UPDATE(HttpStatus.BAD_REQUEST, "PLACE_ID_REQUIRED", "placeId는 필수입니다.");
+    PLACE_ID_REQUIRED_FOR_UPDATE(HttpStatus.BAD_REQUEST, "PLACE_ID_REQUIRED", "placeId는 필수입니다."),
+    INVALID_COUPON_POLICY(HttpStatus.BAD_REQUEST, "INVALID_COUPON_POLICY", "유효하지 않은 쿠폰 정책입니다."),
+    COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "COUPON_NOT_FOUND", "쿠폰을 찾을 수 없습니다.");
+
 
 
     private final HttpStatus status;

--- a/src/main/java/com/unear/admin/places/controller/PlaceController.java
+++ b/src/main/java/com/unear/admin/places/controller/PlaceController.java
@@ -40,7 +40,7 @@ public class PlaceController {
     }
 
     @PlaceDocs.UpdatePlace
-    @PostMapping("/{placeId}")
+    @PutMapping("/{placeId}")
     public ResponseEntity<ApiResponse<String>> updatePlace(
             @PathVariable Long placeId,
             @RequestBody @Valid PlaceRequestDto request


### PR DESCRIPTION
## PR 목적

관리자 쿠폰crud 추가 (스웨거도 바로 추가해서 올리겠습니다, 예외처리 코드도 이때 병합해서 같이 올리도록 하겠습니다)


## 변경 사항
#26 

쿠폰 crud 
CouponTemplateController, CouponTemplateServiceImpl, CouponTemplateService, CouponTemplate, CouponTemplateRequestDto



## 주요 구현 내용

쿠폰 crud 에 필요한 메서드들 추가



## 테스트 및 동작 화면 (필요 시 첨부)

create
<img width="724" height="598" alt="image" src="https://github.com/user-attachments/assets/f7611422-9483-4d26-a7c5-94904b2cd889" />

read
<img width="953" height="671" alt="image" src="https://github.com/user-attachments/assets/e41fb079-67bb-40a6-8e07-f8dd47784eba" />


detail read
<img width="809" height="590" alt="image" src="https://github.com/user-attachments/assets/443e1644-8170-4702-816d-665cb3e9375b" />


update
<img width="733" height="613" alt="image" src="https://github.com/user-attachments/assets/33e01f01-f24c-4796-9472-8dbd31c598d8" />

delete
<img width="636" height="588" alt="image" src="https://github.com/user-attachments/assets/a3696f47-3c66-4e18-b61f-97cba97309ea" />



## 리뷰 시 중점적으로 봐야 할 부분




## 병합 전 체크리스트

- [x] 로컬 테스트 완료
- [x] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [ ] 코드래빗 리뷰 검토
