### PR TITLE
[WL7-352] 팝업스토어와 반경내 제휴처 event_place 에 저장 ( Refactor event place mapping to use location-based automatic search )

### DIFF
--- a/src/main/java/com/unear/admin/common/enums/PlaceType.java
+++ b/src/main/java/com/unear/admin/common/enums/PlaceType.java
@@ -3,8 +3,8 @@ package com.unear.admin.common.enums;
 public enum PlaceType {
     BASIC("BASIC", "기본혜택"),
     FRANCHISE("FRANCHISE", "프랜차이즈"),
-    POPUP("POPUP","팝업스토어");
-//    LOCAL("LOCAL", "우리동네멤버십");
+    POPUP("POPUP","팝업스토어"),
+    LOCAL("LOCAL", "우리동네멤버십");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/unear/admin/event/controller/EventController.java
+++ b/src/main/java/com/unear/admin/event/controller/EventController.java
@@ -32,7 +32,7 @@ public class EventController {
             @PathVariable Long eventId,
             @RequestBody EventPlaceRegistrationRequest request
     ) {
-        eventService.registerPopupAndPartners(eventId, request);
+        eventService.addPlaceToEvent(eventId, request);
         return ResponseEntity.ok(ApiResponse.success("팝업스토어 및 제휴처 등록 완료"));
     }
 

--- a/src/main/java/com/unear/admin/event/dto/request/EventPlaceRegistrationRequest.java
+++ b/src/main/java/com/unear/admin/event/dto/request/EventPlaceRegistrationRequest.java
@@ -1,9 +1,7 @@
 package com.unear.admin.event.dto.request;
 
 import com.unear.admin.places.dto.requestdto.PlaceRequestDto;
-import java.util.List;
 
 public record EventPlaceRegistrationRequest(
-        PlaceRequestDto popupStore,
-        List<Long> partnerPlaceIds
+        PlaceRequestDto popupStore
 ) {}

--- a/src/main/java/com/unear/admin/event/service/EventService.java
+++ b/src/main/java/com/unear/admin/event/service/EventService.java
@@ -3,7 +3,7 @@ package com.unear.admin.event.service;
 import com.unear.admin.coupon.dto.request.CouponTemplateRequestDto;
 import com.unear.admin.event.dto.request.EventPlaceRegistrationRequest;
 import com.unear.admin.event.dto.request.EventRequestDto;
-import com.unear.admin.places.dto.requestdto.PlaceRequestDto;
+
 
 public interface EventService {
 
@@ -12,5 +12,5 @@ public interface EventService {
 
     void addCouponToEvent(Long eventId, CouponTemplateRequestDto dto);
 
-    void registerPopupAndPartners(Long eventId, EventPlaceRegistrationRequest request);
+    void addPlaceToEvent(Long eventId, EventPlaceRegistrationRequest dto);
 }

--- a/src/main/java/com/unear/admin/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/unear/admin/event/service/impl/EventServiceImpl.java
@@ -90,7 +90,13 @@ public class EventServiceImpl implements EventService {
 
     }
     private boolean isSameLocation(Place a, Place b) {
-        return a.getLatitude().compareTo(b.getLatitude()) == 0 &&
-                a.getLongitude().compareTo(b.getLongitude()) == 0;
+        if (a.getLatitude() == null || a.getLongitude() == null ||
+            b.getLatitude() == null || b.getLongitude() == null) {
+            return false;
+        }
+
+        BigDecimal tolerance = new BigDecimal("0.000001"); // 약 0.1미터 정밀도
+        return a.getLatitude().subtract(b.getLatitude()).abs().compareTo(tolerance) <= 0 &&
+               a.getLongitude().subtract(b.getLongitude()).abs().compareTo(tolerance) <= 0;
     }
 }

--- a/src/main/java/com/unear/admin/places/repository/PlaceRepository.java
+++ b/src/main/java/com/unear/admin/places/repository/PlaceRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
@@ -20,5 +21,18 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     )
 """, nativeQuery = true)
     List<Place> findPartnersWithinEventRadius(@Param("eventId") Long eventId);
+
+    @Query(value = """
+    SELECT * FROM places p
+    WHERE ST_DistanceSphere(
+        ST_MakePoint(p.longitude, p.latitude),
+        ST_MakePoint(:lng, :lat)
+    ) <= :radius
+""", nativeQuery = true)
+    List<Place> findWithinRadius(
+            @Param("lat") BigDecimal lat,
+            @Param("lng") BigDecimal lng,
+            @Param("radius") Integer radius
+    );
 
 }


### PR DESCRIPTION
## PR 목적

이벤트 반경 내 모든 제휴처들을 event_place 로 저장



## 변경 사항

#30 
기존 : 관리자가 팝업스토어 1개 + 조회된 이벤트 반경 내 제휴처 3개 선택후 event_place 저장

변경 : 이벤트 반경 조회 후 조회된 반경 내 한곳 팝업스토어 저장 이후 반경 내 모든 제휴처들은 이벤트 제휴처로 저장



## 주요 구현 내용

PlaceRepository 쿼리문 변경
EventServiceImpl addPlaceToEvent 메서드 변경


## 테스트 및 동작 화면 (필요 시 첨부)

<img width="774" height="666" alt="image" src="https://github.com/user-attachments/assets/9ac10fcd-3cf2-4aae-8469-9540f7932c7f" />

<img width="661" height="443" alt="image" src="https://github.com/user-attachments/assets/af54eaa4-30bd-4f86-adec-e8ff37d79cd8" />


## 리뷰 시 중점적으로 봐야 할 부분




## 병합 전 체크리스트

- [x] 로컬 테스트 완료
- [x] Postman 테스트 포함
- [ ] Swagger 동작 확인
- [x] 코드래빗 리뷰 검토
