### PR TITLE
[Wl7-363] 요약 대시보드 api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 ### yml ###
 application-local.yml
 application-secret.yml
+resources/static/dashboard.html

--- a/src/main/java/com/unear/admin/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/com/unear/admin/event/service/impl/EventServiceImpl.java
@@ -20,6 +20,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 

--- a/src/main/java/com/unear/admin/summary/controller/SummaryController.java
+++ b/src/main/java/com/unear/admin/summary/controller/SummaryController.java
@@ -1,0 +1,42 @@
+package com.unear.admin.summary.controller;
+
+import com.unear.admin.summary.dto.response.KeywordSummaryResponseDto;
+import com.unear.admin.summary.service.SummaryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/summary")
+@RequiredArgsConstructor
+public class SummaryController {
+
+    private final SummaryService summaryService;
+
+    @GetMapping("/keywords-benefit")
+    public ResponseEntity<List<KeywordSummaryResponseDto>> getTopBenefitKeywordsByAgeGender(
+            @RequestParam(required = false) String ageGroup,  // 예: "20s"
+            @RequestParam(required = false) String gender   // 예: "M"
+    ) {
+        return ResponseEntity.ok(summaryService.getTop10KeywordsByAgeGender(
+                ageGroup, gender, "AGE_GENDER_KEYWORD_BENEFIT"
+        ));
+    }
+
+    @GetMapping("/keywords-place")
+    public ResponseEntity<List<KeywordSummaryResponseDto>> getTopPlaceKeywordsByAgeGender(
+            @RequestParam(required = false) String ageGroup,
+            @RequestParam(required = false) String gender
+    ) {
+        return ResponseEntity.ok(summaryService.getTop10KeywordsByAgeGender(
+                ageGroup, gender, "AGE_GENDER_KEYWORD_PLACE"
+        ));
+    }
+
+
+}

--- a/src/main/java/com/unear/admin/summary/dto/response/KeywordSummaryResponseDto.java
+++ b/src/main/java/com/unear/admin/summary/dto/response/KeywordSummaryResponseDto.java
@@ -1,0 +1,12 @@
+package com.unear.admin.summary.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class KeywordSummaryResponseDto {
+    private String keyword;
+    private int userCount;
+    private int totalCount;
+}

--- a/src/main/java/com/unear/admin/summary/entity/UserActionSummary.java
+++ b/src/main/java/com/unear/admin/summary/entity/UserActionSummary.java
@@ -1,0 +1,39 @@
+package com.unear.admin.summary.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "user_action_summary")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserActionSummary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "action_type", nullable = false)
+    private String actionType;
+
+    @Column(name = "group_by_field", nullable = false)
+    private String groupByField;
+
+    @Column(name = "group_by_text", nullable = false)
+    private String groupByText;
+
+    @Column(name = "distinct_user_count", nullable = false)
+    private int distinctUserCount;
+
+    @Column(name = "count", nullable = false)
+    private int count;
+
+    @Column(name = "summary_date", nullable = false)
+    private LocalDate summaryDate;
+}

--- a/src/main/java/com/unear/admin/summary/repository/UserActionSummaryRepository.java
+++ b/src/main/java/com/unear/admin/summary/repository/UserActionSummaryRepository.java
@@ -1,0 +1,28 @@
+package com.unear.admin.summary.repository;
+
+import com.unear.admin.summary.dto.response.KeywordSummaryResponseDto;
+import com.unear.admin.summary.entity.UserActionSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+
+import java.util.List;
+
+public interface UserActionSummaryRepository extends JpaRepository<UserActionSummary, Long> {
+
+    @Query("""
+        SELECT new com.unear.admin.summary.dto.response.KeywordSummaryResponseDto(
+            s.groupByText, s.count, s.distinctUserCount
+        )
+        FROM UserActionSummary s
+        WHERE s.actionType = :actionType
+          AND s.groupByField = :group
+        ORDER BY s.count DESC
+        LIMIT 10
+    """)
+    List<KeywordSummaryResponseDto> findTop10KeywordsByGroup(
+            @Param("actionType") String actionType,
+            @Param("group") String group
+    );
+}

--- a/src/main/java/com/unear/admin/summary/service/SummaryService.java
+++ b/src/main/java/com/unear/admin/summary/service/SummaryService.java
@@ -1,0 +1,9 @@
+package com.unear.admin.summary.service;
+
+import com.unear.admin.summary.dto.response.KeywordSummaryResponseDto;
+
+import java.util.List;
+
+public interface SummaryService {
+    List<KeywordSummaryResponseDto> getTop10KeywordsByAgeGender(String ageGroup, String gender, String actionType);
+}

--- a/src/main/java/com/unear/admin/summary/service/impl/SummaryServiceImpl.java
+++ b/src/main/java/com/unear/admin/summary/service/impl/SummaryServiceImpl.java
@@ -1,0 +1,26 @@
+package com.unear.admin.summary.service.impl;
+
+import com.unear.admin.summary.dto.response.KeywordSummaryResponseDto;
+import com.unear.admin.summary.entity.UserActionSummary;
+import com.unear.admin.summary.repository.UserActionSummaryRepository;
+import com.unear.admin.summary.service.SummaryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SummaryServiceImpl implements SummaryService {
+
+    private final UserActionSummaryRepository summaryRepository;
+
+    public List<KeywordSummaryResponseDto> getTop10KeywordsByAgeGender(String ageGroup, String gender, String actionType) {
+        String group = ageGroup + "_" + gender;  // 예: "20s_M"
+        return summaryRepository.findTop10KeywordsByGroup(actionType, group);
+    }
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 8082
+
 spring:
   jpa:
     open-in-view: false
@@ -5,7 +8,6 @@ spring:
   config:
     import:
       - optional:application-local.yml
-      - optional:application-secret.yml
       - optional:application-docker.yml
 
   profiles:


### PR DESCRIPTION
## PR 목적

- 요약용 대시보드를 위한 summary 패키지 추가

## 주요 구현 내용

- SummaryController -> 키워드 인기 순위 조회 api 추가
- UserActionSummary 엔티티 & 레포지토리 추가


## 병합 전 체크리스트

- [v] 로컬 테스트 완료
- [v] Postman 테스트 포함
- [v] 코드래빗 리뷰 검토
